### PR TITLE
Add GitHub Actions workflow to upload package to PyPI

### DIFF
--- a/.github/workflows/upload-to-pypi.yml
+++ b/.github/workflows/upload-to-pypi.yml
@@ -1,0 +1,48 @@
+name: Upload Python Package
+
+on:
+  release:
+    types: [created]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Set up Python
+      uses: actions/setup-python@v2
+      with:
+        python-version: 3.x
+
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install setuptools wheel
+        pip install -e .[dev]
+
+    - name: Run tests
+      run: |
+        pytest
+
+  upload:
+    needs: test
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Set up Python
+      uses: actions/setup-python@v2
+      with:
+        python-version: 3.x
+
+    - name: Build package
+      run: |
+        python setup.py sdist bdist_wheel
+
+    - name: Publish package
+      uses: pypa/gh-action-pypi-publish@release/v1
+      with:
+        password: ${{ secrets.PYPI_API_TOKEN }}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -67,6 +67,7 @@ package-dir = {"op_orm" = "op_orm"}  # Declare the source directory
 dev = [
     "pytest",
     "debugpy",
+    "twine",
 ]
 
 [tool.pytest.ini_options]


### PR DESCRIPTION
Add a GitHub Actions workflow to upload a PyPI package when a new release is created and run pytests before uploading.

* **Add `twine` to `pyproject.toml`**:
  - Add `twine` to the `dev` optional dependencies.

* **Create `.github/workflows/upload-to-pypi.yml`**:
  - Trigger the workflow on the creation of a new release.
  - Add a job to run pytests.
  - Add a job to upload the package to PyPI using `pypa/gh-action-pypi-publish`.

